### PR TITLE
Include utils in pyproject.toml

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -52,6 +52,7 @@ include = [
     "strands_agents_sops/mcp.py",
     "strands_agents_sops/skills.py",
     "strands_agents_sops/rules.py",
+    "strands_agents_sops/utils.py",
     "strands_agents_sops/sops/*.md",
     "strands_agents_sops/rules/*.md"
 ]


### PR DESCRIPTION
Fix bug where utils was removed from target wheel


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
