### PR TITLE
fix: use agent-sops directory name consistently in package

### DIFF
--- a/python/copy_agent_sops_hook.py
+++ b/python/copy_agent_sops_hook.py
@@ -8,7 +8,7 @@ class CustomBuildHook(BuildHookInterface):
     def initialize(self, version, build_data):
         # Copy SOPs
         sops_source_dir = Path("../agent-sops")
-        sops_target_dir = Path("strands_agents_sops/sops")
+        sops_target_dir = Path("strands_agents_sops/agent-sops")
 
         sops_target_dir.mkdir(parents=True, exist_ok=True)
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -28,7 +28,7 @@ lint-fix = "ruff check --fix ."
 clean = [
     "find . -name '__pycache__' -type d | xargs rm -rf",
     "rm -rf strands_agents_sops/rules",
-    "rm -rf strands_agents_sops/sops", 
+    "rm -rf strands_agents_sops/agent-sops", 
     "rm -rf dist",
     "rm -rf build",
     "rm -rf .pytest_cache",
@@ -53,7 +53,7 @@ include = [
     "strands_agents_sops/skills.py",
     "strands_agents_sops/rules.py",
     "strands_agents_sops/utils.py",
-    "strands_agents_sops/sops/*.md",
+    "strands_agents_sops/agent-sops/*.md",
     "strands_agents_sops/rules/*.md"
 ]
 

--- a/python/strands_agents_sops/__init__.py
+++ b/python/strands_agents_sops/__init__.py
@@ -3,7 +3,11 @@ from pathlib import Path
 from .rules import get_sop_format as get_sop_format
 
 # Load all SOP files as module attributes
-_sops_dir = Path(__file__).parent.parent.parent / "agent-sops"
+# Try package directory first (for installed packages), then fallback to development directory
+_sops_dir = Path(__file__).parent / "agent-sops"
+if not _sops_dir.exists() or not list(_sops_dir.glob("*.sop.md")):
+    # Fallback to development directory
+    _sops_dir = Path(__file__).parent.parent.parent / "agent-sops"
 
 for _md_file in _sops_dir.glob("*.sop.md"):
     if _md_file.is_file():

--- a/python/strands_agents_sops/mcp.py
+++ b/python/strands_agents_sops/mcp.py
@@ -50,7 +50,7 @@ def run_mcp_server(sop_paths: str | None = None):
             register_sop(sop["name"], sop["content"], sop["description"])
 
     # Load built-in SOPs last (lower precedence)
-    sops_dir = Path(__file__).parent / "sops"
+    sops_dir = Path(__file__).parent / "agent-sops"
     for md_file in sops_dir.glob("*.sop.md"):
         if md_file.is_file():
             prompt_name = md_file.stem.removesuffix(".sop")

--- a/python/strands_agents_sops/skills.py
+++ b/python/strands_agents_sops/skills.py
@@ -27,7 +27,7 @@ def generate_anthropic_skills(output_dir: str, sop_paths: str | None = None):
                 )
 
     # Process built-in SOPs last (lower precedence)
-    sops_dir = Path(__file__).parent / "sops"
+    sops_dir = Path(__file__).parent / "agent-sops"
     for sop_file in sops_dir.glob("*.sop.md"):
         skill_name = sop_file.stem.removesuffix(".sop")
 


### PR DESCRIPTION
- Update build hook to copy from agent-sops to strands_agents_sops/agent-sops
- Update pyproject.toml to include agent-sops/*.md instead of sops/*.md
- Update clean script to remove agent-sops directory
- Update mcp.py and skills.py to reference agent-sops directory
- Update __init__.py to check package agent-sops directory first, then fallback to development directory

This ensures consistency between source directory name (agent-sops) and package directory name, making the codebase more maintainable.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
