### PR TITLE
Fix SOP import path to use installed package location

### DIFF
--- a/python/strands_agents_sops/__init__.py
+++ b/python/strands_agents_sops/__init__.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from .rules import get_sop_format as get_sop_format
 
 # Load all SOP files as module attributes
-_sops_dir = Path(__file__).parent.parent.parent / "agent-sops"
+_sops_dir = Path(__file__).parent / "sops"
 
 for _md_file in _sops_dir.glob("*.sop.md"):
     if _md_file.is_file():


### PR DESCRIPTION
## Problem
When trying to import SOPs using the documented syntax from the README:
```python
from strands_agents_sops import code_assist
```

The import fails with `ImportError: cannot import name 'code_assist'` because the `__init__.py` is looking for SOPs in the wrong location.

## Root Cause
The `__init__.py` was looking for SOPs at:
```python
Path(__file__).parent.parent.parent / "agent-sops"
```

However, the build hook (`copy_agent_sops_hook.py`) copies SOPs from `agent-sops/` to `strands_agents_sops/sops/` during package build. When the package is installed, the SOPs are located at:
```python
Path(__file__).parent / "sops"
```

## Solution
Updated the path in `__init__.py` to point to the correct installed location.

## Testing
Verified that all SOPs can now be imported successfully:
```python
from strands_agents_sops import code_assist, codebase_summary, code_task_generator, pdd
```

All imports work correctly after this fix.
