### PR TITLE
fix(tests): correct mocking of cursor commands in main tests

### DIFF
--- a/python/strands_agents_sops/cursor.py
+++ b/python/strands_agents_sops/cursor.py
@@ -72,7 +72,7 @@ def _create_command_file(
     # Cursor commands are plain markdown, so we can include the full SOP
     # but we'll add a header to make it clear this is a command
     # Wrap SOP content in XML tags like MCP server does, with "Run this SOP:" prefix
-    command_content = f"""# {command_name.replace('-', ' ').title()}
+    command_content = f"""# {command_name.replace("-", " ").title()}
 
 {description}
 
@@ -126,11 +126,11 @@ This workflow does not require any parameters. Simply execute the command to beg
     for match in re.finditer(param_pattern, parameters_section, re.DOTALL):
         param_name, param_type, default_value, description = match.groups()
         # Clean up description - remove extra whitespace and normalize newlines
-        description = re.sub(r'\s+', ' ', description.strip())
+        description = re.sub(r"\s+", " ", description.strip())
         param_info = {
             "name": param_name,
             "description": description,
-            "default": default_value.strip() if default_value else None
+            "default": default_value.strip() if default_value else None,
         }
 
         if param_type == "required":
@@ -141,7 +141,9 @@ This workflow does not require any parameters. Simply execute the command to beg
     instructions = ["## Parameters\n"]
 
     if required_params or optional_params:
-        instructions.append("When you execute this command, I will prompt you for the following parameters:\n")
+        instructions.append(
+            "When you execute this command, I will prompt you for the following parameters:\n"
+        )
 
         if required_params:
             instructions.append("### Required Parameters\n")
@@ -151,11 +153,19 @@ This workflow does not require any parameters. Simply execute the command to beg
         if optional_params:
             instructions.append("### Optional Parameters\n")
             for param in optional_params:
-                default_text = f" (default: {param['default']})" if param['default'] else ""
-                instructions.append(f"- **{param['name']}**: {param['description']}{default_text}\n")
+                default_text = (
+                    f" (default: {param['default']})" if param["default"] else ""
+                )
+                instructions.append(
+                    f"- **{param['name']}**: {param['description']}{default_text}\n"
+                )
 
-        instructions.append("\n**Note**: Please provide all required parameters when prompted. Optional parameters can be skipped to use their default values.\n")
+        instructions.append(
+            "\n**Note**: Please provide all required parameters when prompted. Optional parameters can be skipped to use their default values.\n"
+        )
     else:
-        instructions.append("This workflow does not require any parameters. Simply execute the command to begin.\n")
+        instructions.append(
+            "This workflow does not require any parameters. Simply execute the command to begin.\n"
+        )
 
     return "".join(instructions)

--- a/python/tests/test_main.py
+++ b/python/tests/test_main.py
@@ -35,17 +35,46 @@ def test_main_mcp_with_paths(mock_run_mcp):
     mock_run_mcp.assert_called_once_with(sop_paths="/test/path")
 
 
-@patch("strands_agents_sops.__main__.generate_cursor_commands")
-@patch("sys.argv", ["strands-agents-sops", "commands", "--type", "cursor", "--output-dir", "test-dir"])
-def test_main_commands_cursor(mock_generate):
+@patch(
+    "sys.argv",
+    ["strands-agents-sops", "commands", "--type", "cursor", "--output-dir", "test-dir"],
+)
+def test_main_commands_cursor():
     """Test main function with commands --type cursor"""
-    main()
-    mock_generate.assert_called_once_with("test-dir", sop_paths=None)
+    from unittest.mock import MagicMock
+
+    mock_func = MagicMock()
+
+    # Patch the registry with our mock
+    with patch(
+        "strands_agents_sops.__main__.COMMAND_GENERATORS",
+        {"cursor": (mock_func, ".cursor/commands")},
+    ):
+        main()
+        mock_func.assert_called_once_with("test-dir", sop_paths=None)
 
 
-@patch("strands_agents_sops.__main__.generate_cursor_commands")
-@patch("sys.argv", ["strands-agents-sops", "commands", "--type", "cursor", "--sop-paths", "/test/path"])
-def test_main_commands_cursor_with_paths(mock_generate):
+@patch(
+    "sys.argv",
+    [
+        "strands-agents-sops",
+        "commands",
+        "--type",
+        "cursor",
+        "--sop-paths",
+        "/test/path",
+    ],
+)
+def test_main_commands_cursor_with_paths():
     """Test main function with commands --type cursor and sop-paths"""
-    main()
-    mock_generate.assert_called_once_with(".cursor/commands", sop_paths="/test/path")
+    from unittest.mock import MagicMock
+
+    mock_func = MagicMock()
+
+    # Patch the registry with our mock
+    with patch(
+        "strands_agents_sops.__main__.COMMAND_GENERATORS",
+        {"cursor": (mock_func, ".cursor/commands")},
+    ):
+        main()
+        mock_func.assert_called_once_with(".cursor/commands", sop_paths="/test/path")


### PR DESCRIPTION
- Mock COMMAND_GENERATORS registry instead of function import
- Function references are captured at import time in registry
- Fixes failing CI tests for cursor command generation

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
