### PR TITLE
fix: add cursor.py to build target

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -49,6 +49,7 @@ python = ["3.10", "3.11", "3.12"]
 include = [
     "strands_agents_sops/__init__.py",
     "strands_agents_sops/__main__.py",
+    "strands_agents_sops/cursor.py",
     "strands_agents_sops/mcp.py",
     "strands_agents_sops/skills.py",
     "strands_agents_sops/rules.py",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

It seems that the newly added `cursor.py` is missing in a build target, so here I add.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
