### PR TITLE
Fix PDD SOP design->implementation phase transition

### DIFF
--- a/agent-sops/pdd.sop.md
+++ b/agent-sops/pdd.sop.md
@@ -157,6 +157,8 @@ Develop a comprehensive design document based on the requirements and research.
 - You MUST ensure the design addresses all requirements identified during the clarification process
 - You SHOULD highlight design decisions and their rationales, referencing research findings where applicable
 - You MUST review the design with the user and iterate based on feedback
+- You MUST explicitly ask the user if they are ready to proceed to implementation before moving to Step 7
+- You MUST NOT proceed to the implementation plan step without explicit user confirmation because this could skip important design refinement
 - You MUST offer to return to requirements clarification or research if gaps are identified during design
 
 ### 7. Develop Implementation Plan


### PR DESCRIPTION
Add explicit 'ask before proceeding' constraints to Step 6 (Design) to match the pattern in Step 3 (Requirements).

Problem:
- Agents could jump from design to implementation without asking
- This often wasted time and context window

Solution:
- Added: MUST explicitly ask if ready to proceed to implementation
- Added: MUST NOT proceed without explicit user confirmation

Tested with [Strands Evals](https://github.com/strands-agents/evals) across 5 models:
- Nova models: 100% pass rate after fix
- Full results: https://github.com/rubencu/pdd-sop-eval

Fixes #28
