### PR TITLE
fix: support semicolon path separator for Windows compatibility in --sop-paths

### DIFF
--- a/python/strands_agents_sops/__main__.py
+++ b/python/strands_agents_sops/__main__.py
@@ -25,7 +25,7 @@ def main():
     mcp_parser = subparsers.add_parser("mcp", help="Run MCP server (default)")
     mcp_parser.add_argument(
         "--sop-paths",
-        help="Colon-separated list of directory paths to load external SOPs from. "
+        help="Separated list of directory paths (use semicolons on Windows, colons on Unix) to load external SOPs from. "
         "Supports absolute paths, relative paths, and tilde (~) expansion.",
     )
 
@@ -38,7 +38,7 @@ def main():
     )
     skills_parser.add_argument(
         "--sop-paths",
-        help="Colon-separated list of directory paths to load external SOPs from. "
+        help="Separated list of directory paths (use semicolons on Windows, colons on Unix) to load external SOPs from. "
         "Supports absolute paths, relative paths, and tilde (~) expansion.",
     )
 
@@ -61,7 +61,7 @@ def main():
     )
     commands_parser.add_argument(
         "--sop-paths",
-        help="Colon-separated list of directory paths to load external SOPs from. "
+        help="Separated list of directory paths (use semicolons on Windows, colons on Unix) to load external SOPs from. "
         "Supports absolute paths, relative paths, and tilde (~) expansion.",
     )
 

--- a/python/strands_agents_sops/utils.py
+++ b/python/strands_agents_sops/utils.py
@@ -9,8 +9,12 @@ logger = logging.getLogger(__name__)
 def expand_sop_paths(sop_paths_str: str) -> list[Path]:
     """Expand and validate SOP directory paths.
 
+    Paths are separated by `os.pathsep` (`:` on Unix, `;` on Windows) so that
+    Windows drive letters like ``C:\\Users\\...`` are not misinterpreted as
+    separators.  For backward compatibility, `;` is also accepted on Unix.
+
     Args:
-        sop_paths_str: Colon-separated string of directory paths
+        sop_paths_str: Separator-delimited string of directory paths
 
     Returns:
         List of expanded Path objects
@@ -18,8 +22,18 @@ def expand_sop_paths(sop_paths_str: str) -> list[Path]:
     if not sop_paths_str:
         return []
 
+    # On Windows os.pathsep is ";", on Unix it is ":".
+    # Always split on ";" first so that it works cross-platform.
+    # Only fall back to ":" when no ";" is present (pure-Unix shorthand).
+    import os
+
+    if ";" in sop_paths_str:
+        parts = sop_paths_str.split(";")
+    else:
+        parts = sop_paths_str.split(os.pathsep)
+
     paths = []
-    for path_str in sop_paths_str.split(":"):
+    for path_str in parts:
         path_str = path_str.strip()
         if not path_str:
             continue

--- a/python/tests/test_utils.py
+++ b/python/tests/test_utils.py
@@ -15,6 +15,19 @@ def test_expand_sop_paths_with_empty_parts():
     assert len(result) == 2
 
 
+def test_expand_sop_paths_semicolon_separator():
+    """Test expand_sop_paths with semicolon separator (cross-platform)"""
+    result = expand_sop_paths("/path1;/path2")
+    assert len(result) == 2
+
+
+def test_expand_sop_paths_semicolon_with_windows_drive():
+    """Test expand_sop_paths preserves Windows drive letters when using semicolons"""
+    # Semicolons must be used on Windows to avoid splitting on the colon in C:\...
+    result = expand_sop_paths("C:\\Users\\sops;D:\\other\\sops")
+    assert len(result) == 2
+
+
 def test_load_external_sops_nonexistent_directory():
     """Test load_external_sops with non-existent directory"""
     with patch("strands_agents_sops.utils.logger") as mock_logger:


### PR DESCRIPTION
## Problem

`--sop-paths` uses `:` (colon) as the path separator, which conflicts with Windows drive letters like `C:\Users\sops`. This causes `expand_sop_paths()` to split incorrectly on Windows, resulting in broken paths.

## Solution

- Accept `;` (semicolon) as a cross-platform path separator
- When `;` is present in the input string, split on `;` (safe for both Windows and Unix)
- When no `;` is present, fall back to `os.pathsep` (`:` on Unix, `;` on Windows)
- Update CLI help text to document the cross-platform behavior
- Add tests for semicolon separator and Windows drive letter paths

## Backward Compatibility

Existing Unix users passing `/path1:/path2` are unaffected — the fallback to `os.pathsep` preserves the old behavior when no semicolons are present.