### PR TITLE
fix: simplify sop-paths separator logic and improve help text

### DIFF
--- a/python/strands_agents_sops/__main__.py
+++ b/python/strands_agents_sops/__main__.py
@@ -25,7 +25,7 @@ def main():
     mcp_parser = subparsers.add_parser("mcp", help="Run MCP server (default)")
     mcp_parser.add_argument(
         "--sop-paths",
-        help="Separated list of directory paths (use semicolons on Windows, colons on Unix) to load external SOPs from. "
+        help="Directory paths separated by semicolons (;) on Windows or colons (:) on Unix to load external SOPs from. "
         "Supports absolute paths, relative paths, and tilde (~) expansion.",
     )
 
@@ -38,7 +38,7 @@ def main():
     )
     skills_parser.add_argument(
         "--sop-paths",
-        help="Separated list of directory paths (use semicolons on Windows, colons on Unix) to load external SOPs from. "
+        help="Directory paths separated by semicolons (;) on Windows or colons (:) on Unix to load external SOPs from. "
         "Supports absolute paths, relative paths, and tilde (~) expansion.",
     )
 
@@ -61,7 +61,7 @@ def main():
     )
     commands_parser.add_argument(
         "--sop-paths",
-        help="Separated list of directory paths (use semicolons on Windows, colons on Unix) to load external SOPs from. "
+        help="Directory paths separated by semicolons (;) on Windows or colons (:) on Unix to load external SOPs from. "
         "Supports absolute paths, relative paths, and tilde (~) expansion.",
     )
 

--- a/python/strands_agents_sops/utils.py
+++ b/python/strands_agents_sops/utils.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import re
 from pathlib import Path
 from typing import Any
@@ -9,9 +10,9 @@ logger = logging.getLogger(__name__)
 def expand_sop_paths(sop_paths_str: str) -> list[Path]:
     """Expand and validate SOP directory paths.
 
-    Paths are separated by `os.pathsep` (`:` on Unix, `;` on Windows) so that
-    Windows drive letters like ``C:\\Users\\...`` are not misinterpreted as
-    separators.  For backward compatibility, `;` is also accepted on Unix.
+    Paths are separated by ``os.pathsep`` (``:`` on Unix, ``;`` on Windows) so
+    that Windows drive letters like ``C:\\Users\\...`` are not misinterpreted as
+    separators.
 
     Args:
         sop_paths_str: Separator-delimited string of directory paths
@@ -22,18 +23,8 @@ def expand_sop_paths(sop_paths_str: str) -> list[Path]:
     if not sop_paths_str:
         return []
 
-    # On Windows os.pathsep is ";", on Unix it is ":".
-    # Always split on ";" first so that it works cross-platform.
-    # Only fall back to ":" when no ";" is present (pure-Unix shorthand).
-    import os
-
-    if ";" in sop_paths_str:
-        parts = sop_paths_str.split(";")
-    else:
-        parts = sop_paths_str.split(os.pathsep)
-
     paths = []
-    for path_str in parts:
+    for path_str in sop_paths_str.split(os.pathsep):
         path_str = path_str.strip()
         if not path_str:
             continue

--- a/python/tests/test_utils.py
+++ b/python/tests/test_utils.py
@@ -16,16 +16,17 @@ def test_expand_sop_paths_with_empty_parts():
 
 
 def test_expand_sop_paths_semicolon_separator():
-    """Test expand_sop_paths with semicolon separator (cross-platform)"""
-    result = expand_sop_paths("/path1;/path2")
-    assert len(result) == 2
+    """Test expand_sop_paths with semicolon separator (Windows-style)"""
+    with patch("strands_agents_sops.utils.os.pathsep", ";"):
+        result = expand_sop_paths("/path1;/path2")
+        assert len(result) == 2
 
 
 def test_expand_sop_paths_semicolon_with_windows_drive():
     """Test expand_sop_paths preserves Windows drive letters when using semicolons"""
-    # Semicolons must be used on Windows to avoid splitting on the colon in C:\...
-    result = expand_sop_paths("C:\\Users\\sops;D:\\other\\sops")
-    assert len(result) == 2
+    with patch("strands_agents_sops.utils.os.pathsep", ";"):
+        result = expand_sop_paths("C:\\Users\\sops;D:\\other\\sops")
+        assert len(result) == 2
 
 
 def test_load_external_sops_nonexistent_directory():


### PR DESCRIPTION
- Move 'import os' to module top per PEP 8
- Replace conditional semicolon/colon splitting with os.pathsep
- Improve --sop-paths help text clarity
- Mock os.pathsep in tests for proper cross-platform coverage

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
