### PR TITLE
feat(pdd): Make detailed design self-contained, no local file refs

### DIFF
--- a/agent-sops/pdd.sop.md
+++ b/agent-sops/pdd.sop.md
@@ -139,6 +139,9 @@ Develop a comprehensive design document based on the requirements and research.
 **Constraints:**
 - You MUST create a detailed design document at {project_dir}/design/detailed-design.md
 - You MUST write the design as a standalone document that can be understood without reading other project files
+- You MUST NOT reference or link to local project files or file paths within the detailed design (e.g., files under {project_dir}/research/, idea-honing.md, or rough-idea.md) because these files are unavailable when the design is shared, published to a review system, or read outside the local environment, which breaks the document for reviewers
+- You MUST inline any content needed from research or other project files (findings, diagrams, data, rationale) directly into the design rather than pointing to those files, so the design remains durable and self-contained
+- You MAY include links to durable external references (public documentation, internal wikis, articles, or other URLs) since these remain accessible to reviewers outside the local environment
 - You MUST include the following sections in the design document:
   - Overview
   - Detailed Requirements (consolidated from idea-honing.md)
@@ -157,7 +160,7 @@ Develop a comprehensive design document based on the requirements and research.
 - You SHOULD include diagrams or visual representations when appropriate using mermaid syntax
 - You MUST generate mermaid diagrams for architectural overviews, data flow, and component relationships
 - You MUST ensure the design addresses all requirements identified during the clarification process
-- You SHOULD highlight design decisions and their rationales, referencing research findings where applicable
+- You SHOULD highlight design decisions and their rationales, drawing on relevant research findings
 - You MUST review the design with the user and iterate based on feedback
 - You MUST explicitly ask the user if they are ready to proceed to implementation before moving to Step 7
 - You MUST NOT proceed to the implementation plan step without explicit user confirmation because this could skip important design refinement


### PR DESCRIPTION
## What

Adds explicit constraints to the **Create Detailed Design** step (Step 6) of the PDD SOP so the detailed design is durable and self-contained, and does not reference local project files.

## Why

In practice, the detailed design produced by this SOP almost always ends up linking to local project files — most often the research notes under `{project_dir}/research/`. Those links break the moment the design leaves the local environment:

- Publishing the design to a review system (where people comment and the author iterates on feedback) leaves dangling references to files reviewers can't see.
- Sharing the design as a standalone artifact loses the context the links pointed to.

Step 6 already said the design "MUST ... be understood without reading other project files," but it never forbade the references, so agents kept adding them. The constraint `referencing research findings where applicable` also nudged toward linking rather than inlining.

## Change

In Step 6:
- Add `MUST NOT` reference or link local project files/paths (e.g., `{project_dir}/research/`, `idea-honing.md`, `rough-idea.md`) within the detailed design.
- Add `MUST` inline any needed content (findings, diagrams, data, rationale) directly into the design.
- Add `MAY` include links to durable external references (public docs, internal wikis, URLs), which remain accessible to reviewers.
- Reword the design-rationale constraint to incorporate research findings inline rather than linking to research files.

No code changes — SOP markdown content only.

## Testing

Ran the Python test suite (`pytest`); all SOP-loading/content tests pass. (The only failures observed were two pre-existing `~`/home-path expansion tests unrelated to this change and dependent on the local environment.)
