### PR TITLE
refactor: rename Anthropic skills to Agent Skills

### DIFF
--- a/.github/workflows/publish-skills.yml
+++ b/.github/workflows/publish-skills.yml
@@ -56,7 +56,7 @@ jobs:
             git checkout --orphan skills-dist
             git rm -rf . || true
             touch .nojekyll
-            printf '%s\n' '# Skills Distribution' '' 'This branch contains auto-generated Claude Code skills from the main branch.' '' 'Generated from: https://github.com/strands-agents/agent-sop' > README.md
+            printf '%s\n' '# Skills Distribution' '' 'This branch contains auto-generated Agent Skills from the main branch.' '' 'Generated from: https://github.com/strands-agents/agent-sop' > README.md
           fi
 
           rm -rf skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS.md - AI Assistant Context for Agent SOP Project
 
 ## Project Overview
-Agent SOP provides natural language workflows that enable AI agents to perform complex, multi-step tasks with consistency and reliability. This is a Python package that implements the Model Context Protocol (MCP) for AI assistant integration and supports conversion to Anthropic Skills format.
+Agent SOP provides natural language workflows that enable AI agents to perform complex, multi-step tasks with consistency and reliability. This is a Python package that implements the Model Context Protocol (MCP) for AI assistant integration and supports conversion to Agent Skills format.
 
 ## Directory Structure
 
@@ -10,7 +10,7 @@ agent-sop/
 ├── python/strands_agents_sops/    # Main Python package
 │   ├── __main__.py               # CLI entry point (mcp|skills|rule commands)
 │   ├── mcp.py                    # MCP server implementation
-│   ├── skills.py                 # Anthropic Skills conversion
+│   ├── skills.py                 # Agent Skills conversion
 │   └── utils.py                  # Shared SOP utilities
 ├── agent-sops/                   # Source SOP definitions
 │   ├── codebase-summary.sop.md   # Documentation generation workflow
@@ -123,7 +123,7 @@ strands-agents-sops mcp --sop-paths ~/my-sops:/team/sops
 
 ### Skills Integration
 ```bash
-# Generate Skills format for Claude
+# Generate Agent Skills format
 strands-agents-sops skills --output-dir ./skills
 
 # Include custom SOPs in Skills generation

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Agent SOPs use a standardized format to define:
 - **Parameterized inputs** for flexible reuse across different contexts
 - **Step-by-step instructions** with RFC 2119 constraints (MUST, SHOULD, MAY)
 - **Examples and troubleshooting** for reliable execution
-- **Multi-modal distribution** (MCP tools, Anthropic Skills, Python modules)
+- **Multi-modal distribution** (MCP tools, Agent Skills, Python modules)
 
 ### Example SOP Structure
 
@@ -380,29 +380,29 @@ This approach maintains the parameterized nature of SOPs while working within Cu
 
 ---
 
-## Anthropic Skills Integration
+## Agent Skills Integration
 
-Agent SOPs are fully compatible with Claude's [Skills system](https://support.claude.com/en/articles/12512176-what-are-skills), allowing you to teach Claude specialized workflows that can be reused across conversations and projects.
+Agent SOPs can be generated as [Agent Skills](https://agentskills.io/), the open `SKILL.md` format supported by Claude and other skill-compatible agents. This lets you teach agents specialized SOP workflows that can be reused across conversations and projects.
 
 ### How SOPs Work as Skills
 
-The key value of using SOPs as Skills is **progressive disclosure of context**. Instead of loading all workflow instructions into Claude's context upfront, you can provide many SOP skills to Claude, and Claude will intelligently decide which ones to load and execute based on the task at hand.
+The key value of using SOPs as Skills is **progressive disclosure of context**. Instead of loading all workflow instructions into an agent's context upfront, you can provide many SOP skills, and the agent can load and execute the relevant workflow based on the task at hand.
 
 This approach offers several advantages:
 
 - **Context Efficiency**: Only relevant workflow instructions are loaded when needed
 - **Scalable Expertise**: Provide dozens of specialized workflows without overwhelming the context
-- **Intelligent Selection**: Claude automatically chooses the most appropriate SOP for each task
-- **Dynamic Loading**: Complex workflows are only activated when Claude determines they're useful
+- **Intelligent Selection**: Agents can choose the most appropriate SOP for each task
+- **Dynamic Loading**: Complex workflows are only activated when the agent determines they're useful
 
-For example, you might provide Claude with all Agent SOPs as skills. When asked to "implement user authentication," Claude would automatically select and load the `code-assist` skill. When asked to "document this codebase," it would choose the `codebase-summary` skill instead.
+For example, you might provide an agent with all Agent SOPs as skills. When asked to "implement user authentication," the agent can select and load the `code-assist` skill. When asked to "document this codebase," it can choose the `codebase-summary` skill instead.
 
 ### Converting SOPs to Skills
 
-Each Agent SOP can be automatically converted to Anthropic's Skills format:
+Each Agent SOP can be automatically converted to Agent Skills format:
 
 ```bash
-# Generate Skills format from built-in SOPs only
+# Generate Agent Skills from built-in SOPs only
 strands-agents-sops skills
 
 # Or specify custom output directory
@@ -454,6 +454,8 @@ skills/
 └── pdd/
     └── SKILL.md
 ```
+
+Each generated `SKILL.md` contains the SOP workflow in standard Agent Skills format.
 
 ### Using Skills in Claude
 

--- a/python/README.md
+++ b/python/README.md
@@ -13,7 +13,7 @@
   </p>
 </div>
 
-A comprehensive Python package that provides Agent Standard Operating Procedures (SOPs) as importable strings, structured prompts for AI agents via Model Context Protocol (MCP), and Anthropic Skills generation capabilities.
+A comprehensive Python package that provides Agent Standard Operating Procedures (SOPs) as importable strings, structured prompts for AI agents via Model Context Protocol (MCP), and Agent Skills generation capabilities.
 
 ## 🚀 Quick Start
 
@@ -81,10 +81,10 @@ Remove `--sop-paths` if you only want the built-in SOPs.
 
 After updating the config, restart Kiro CLI or reload MCP servers. You do not need to run `strands-agents-sops mcp` in a separate terminal once Kiro is configured.
 
-### Anthropic Skills Generation
+### Agent Skills Generation
 
 ```bash
-# Generate skills for Claude
+# Generate Agent Skills for Claude and other skill-compatible agents
 strands-agents-sops skills
 
 # Custom output directory

--- a/python/strands_agents_sops/__main__.py
+++ b/python/strands_agents_sops/__main__.py
@@ -3,7 +3,7 @@ import argparse
 from .cursor import generate_cursor_commands
 from .mcp import run_mcp_server
 from .rules import output_rules
-from .skills import generate_anthropic_skills
+from .skills import generate_agent_skills
 
 # Registry for command generators: maps type -> (generator_function, default_output_dir)
 COMMAND_GENERATORS = {
@@ -30,7 +30,7 @@ def main():
     )
 
     # Skills generation command
-    skills_parser = subparsers.add_parser("skills", help="Generate Anthropic skills")
+    skills_parser = subparsers.add_parser("skills", help="Generate Agent Skills")
     skills_parser.add_argument(
         "--output-dir",
         default="skills",
@@ -69,7 +69,7 @@ def main():
 
     if args.command == "skills":
         sop_paths = getattr(args, "sop_paths", None)
-        generate_anthropic_skills(args.output_dir, sop_paths=sop_paths)
+        generate_agent_skills(args.output_dir, sop_paths=sop_paths)
     elif args.command == "rule":
         output_rules()
     elif args.command == "commands":

--- a/python/strands_agents_sops/skills.py
+++ b/python/strands_agents_sops/skills.py
@@ -7,8 +7,8 @@ from .utils import expand_sop_paths, load_external_sops
 logger = logging.getLogger(__name__)
 
 
-def generate_anthropic_skills(output_dir: str, sop_paths: str | None = None):
-    """Generate Anthropic skills from SOPs"""
+def generate_agent_skills(output_dir: str, sop_paths: str | None = None):
+    """Generate Agent Skills from SOPs"""
     output_path = Path(output_dir)
     output_path.mkdir(exist_ok=True)
 
@@ -45,7 +45,7 @@ def generate_anthropic_skills(output_dir: str, sop_paths: str | None = None):
             description = overview_match.group(1).strip().replace("\n", " ")
             _create_skill_file(output_path, skill_name, content, description)
 
-    print(f"\nAnthropic skills generated in: {output_path.absolute()}")
+    print(f"\nAgent Skills generated in: {output_path.absolute()}")
 
 
 def _create_skill_file(
@@ -65,4 +65,4 @@ description: {description}
 
     skill_file = skill_dir / "SKILL.md"
     skill_file.write_text(frontmatter + content)
-    print(f"Created Anthropic skill: {skill_file}")
+    print(f"Created Agent Skill: {skill_file}")

--- a/python/tests/test_main.py
+++ b/python/tests/test_main.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 from strands_agents_sops.__main__ import main
 
 
-@patch("strands_agents_sops.__main__.generate_anthropic_skills")
+@patch("strands_agents_sops.__main__.generate_agent_skills")
 @patch("sys.argv", ["strands-agents-sops", "skills", "--output-dir", "test-dir"])
 def test_main_skills_command(mock_generate):
     """Test main function with skills command"""

--- a/python/tests/test_skills_external_sops.py
+++ b/python/tests/test_skills_external_sops.py
@@ -2,7 +2,7 @@ import tempfile
 from pathlib import Path
 from unittest.mock import patch
 
-from strands_agents_sops.skills import generate_anthropic_skills
+from strands_agents_sops.skills import generate_agent_skills
 
 
 class TestSkillsCLIIntegration:
@@ -11,7 +11,7 @@ class TestSkillsCLIIntegration:
     def test_skills_accepts_sop_paths_argument(self):
         """Test that skills subcommand accepts --sop-paths argument"""
         with patch(
-            "strands_agents_sops.__main__.generate_anthropic_skills"
+            "strands_agents_sops.__main__.generate_agent_skills"
         ) as mock_generate:
             with patch(
                 "sys.argv",
@@ -25,7 +25,7 @@ class TestSkillsCLIIntegration:
     def test_skills_accepts_both_arguments(self):
         """Test that skills subcommand accepts both --sop-paths and --output-dir"""
         with patch(
-            "strands_agents_sops.__main__.generate_anthropic_skills"
+            "strands_agents_sops.__main__.generate_agent_skills"
         ) as mock_generate:
             with patch(
                 "sys.argv",
@@ -46,7 +46,7 @@ class TestSkillsCLIIntegration:
     def test_skills_backward_compatibility(self):
         """Test that skills subcommand works without --sop-paths"""
         with patch(
-            "strands_agents_sops.__main__.generate_anthropic_skills"
+            "strands_agents_sops.__main__.generate_agent_skills"
         ) as mock_generate:
             with patch(
                 "sys.argv",
@@ -81,7 +81,7 @@ Test step content.
             sop_file.write_text(external_sop)
 
             with tempfile.TemporaryDirectory() as output_dir:
-                generate_anthropic_skills(output_dir, sop_paths=temp_dir)
+                generate_agent_skills(output_dir, sop_paths=temp_dir)
 
                 # Check that external SOP skill was created
                 skill_file = Path(output_dir) / "external-test" / "SKILL.md"
@@ -112,7 +112,7 @@ Custom implementation.
             sop_file.write_text(external_sop)
 
             with tempfile.TemporaryDirectory() as output_dir:
-                generate_anthropic_skills(output_dir, sop_paths=temp_dir)
+                generate_agent_skills(output_dir, sop_paths=temp_dir)
 
                 # Check that external version was used
                 skill_file = Path(output_dir) / "code-assist" / "SKILL.md"
@@ -145,7 +145,7 @@ This is the second version that should be ignored.
             (Path(temp_dir2) / "test.sop.md").write_text(sop2)
 
             with tempfile.TemporaryDirectory() as output_dir:
-                generate_anthropic_skills(
+                generate_agent_skills(
                     output_dir, sop_paths=f"{temp_dir1}:{temp_dir2}"
                 )
 
@@ -181,7 +181,7 @@ Content.
             (Path(temp_dir) / "valid.sop.md").write_text(valid_sop)
 
             with tempfile.TemporaryDirectory() as output_dir:
-                generate_anthropic_skills(output_dir, sop_paths=temp_dir)
+                generate_agent_skills(output_dir, sop_paths=temp_dir)
 
                 # Check that only valid SOP was processed
                 assert not (Path(output_dir) / "invalid").exists()
@@ -191,7 +191,7 @@ Content.
         """Test that non-existent directories are handled gracefully"""
         with tempfile.TemporaryDirectory() as output_dir:
             # Should not raise exception
-            generate_anthropic_skills(output_dir, sop_paths="/nonexistent/path")
+            generate_agent_skills(output_dir, sop_paths="/nonexistent/path")
 
             # Built-in SOPs should still be processed
             builtin_skills = list(Path(output_dir).glob("*/SKILL.md"))
@@ -220,7 +220,7 @@ Second SOP.
             (Path(temp_dir2) / "sop-two.sop.md").write_text(sop2)
 
             with tempfile.TemporaryDirectory() as output_dir:
-                generate_anthropic_skills(
+                generate_agent_skills(
                     output_dir, sop_paths=f"{temp_dir1}:{temp_dir2}"
                 )
 
@@ -231,7 +231,7 @@ Second SOP.
     def test_backward_compatibility_no_sop_paths(self):
         """Test that skills generation works without sop_paths parameter"""
         with tempfile.TemporaryDirectory() as output_dir:
-            generate_anthropic_skills(output_dir)
+            generate_agent_skills(output_dir)
 
             # Should generate built-in skills
             builtin_skills = list(Path(output_dir).glob("*/SKILL.md"))
@@ -244,7 +244,7 @@ Second SOP.
     def test_skill_frontmatter_simplified(self):
         """Test that generated skills have simplified frontmatter without type/version"""
         with tempfile.TemporaryDirectory() as output_dir:
-            generate_anthropic_skills(output_dir)
+            generate_agent_skills(output_dir)
 
             skill_file = Path(output_dir) / "code-assist" / "SKILL.md"
             assert skill_file.exists()

--- a/skills/agent-sop-author/SKILL.md
+++ b/skills/agent-sop-author/SKILL.md
@@ -31,7 +31,7 @@ An Agent SOP is a standardized markdown file (`.sop.md`) that defines:
 - **Parameterized inputs** for flexible reuse
 - **Step-by-step instructions** with RFC 2119 constraints
 - **Examples and troubleshooting** for reliable execution
-- **Multi-modal distribution** (MCP tools, Anthropic Skills, Python modules)
+- **Multi-modal distribution** (MCP tools, Agent Skills, Python modules)
 
 ### Key Features
 


### PR DESCRIPTION
## Summary

- Rename skills-related wording from Anthropic Skills to Agent Skills across documentation and generated-skill publishing text.
- Rename the skills generator helper from `generate_anthropic_skills` to `generate_agent_skills`.
- Update tests and CLI wiring to use the new helper name while preserving the existing `strands-agents-sops skills` command behavior.

## Why

The generated output follows the Agent Skills `SKILL.md` format rather than an Anthropic-only integration. The Agent Skills site describes skills as an open format built around a folder containing `SKILL.md`, and the specification defines the same directory and frontmatter shape this project generates. Anthropic also refers to the feature as Agent Skills in its Claude API documentation.

Relevant references:

- [Agent Skills overview](https://agentskills.io/home)
- [Agent Skills specification](https://agentskills.io/specification)
- [Anthropic Claude API docs: Agent Skills](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview)

## Validation

- `cd python && /tmp/agent-sop-hatch-venv/bin/hatch test`
- `cd python && /tmp/agent-sop-hatch-venv/bin/hatch run lint`
- `git diff --check`