### PR TITLE
ci: add test and lint workflow for PR status checks

### DIFF
--- a/.github/workflows/pr-and-push.yml
+++ b/.github/workflows/pr-and-push.yml
@@ -1,0 +1,19 @@
+name: Pull Request and Push Action
+
+on:
+  pull_request:
+    branches: [ main ]
+    types: [opened, synchronize, reopened, ready_for_review, review_requested, review_request_removed]
+  push:
+    branches: [ main ]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  call-test-lint:
+    uses: ./.github/workflows/test-lint.yml
+    permissions:
+      contents: read
+    with:
+      ref: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -1,0 +1,42 @@
+name: Test and Lint
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        required: true
+        type: string
+
+jobs:
+  test-lint:
+    name: Test and Lint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          persist-credentials: false
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+
+      - name: Install hatch
+        run: pip install --no-cache-dir hatch
+
+      - name: Run lint
+        working-directory: python
+        run: hatch run lint
+
+      - name: Run tests
+        working-directory: python
+        run: hatch test --python ${{ matrix.python-version }}

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
 ]
 
 [[tool.hatch.envs.hatch-test.matrix]]
-python = ["3.10", "3.11", "3.12"]
+python = ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
 [tool.hatch.build.targets.wheel]
 include = [


### PR DESCRIPTION
## Summary

Adds a CI workflow so lint and tests can be enforced as a required status check on PRs.

- **`.github/workflows/test-lint.yml`** — reusable workflow (`workflow_call`) that runs `hatch run lint` and `hatch test` in the `python/` directory across a Python version matrix (3.10, 3.11, 3.12, 3.13, 3.14). Each matrix job provisions a single interpreter via `actions/setup-python` and pins hatch to it with `--python`.
- **`.github/workflows/pr-and-push.yml`** — trigger that calls the reusable workflow on PRs to `main` and pushes to `main`, with concurrency cancellation for superseded runs.
- **`python/pyproject.toml`** — extend the `hatch-test` matrix to include 3.13 and 3.14 so it matches the CI matrix.

Follows the reusable two-file pattern used in other Strands repos, adapted for this package's `python/` subdirectory and hatch test matrix.

## Validation

Ran locally across the full matrix:

- `cd python && hatch run lint` — passes
- `cd python && hatch test --python 3.10|3.11|3.12|3.13|3.14` — 43 passed, 94% coverage on each