### PR TITLE
fix(ci): sha-pin third-party GitHub Actions

### DIFF
--- a/.github/workflows/pypi-publish-on-release.yml
+++ b/.github/workflows/pypi-publish-on-release.yml
@@ -92,4 +92,4 @@ jobs:
         name: python-package-distributions
         path: dist/
     - name: Publish distribution 📦 to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1


### PR DESCRIPTION
Pin all third-party actions to their current commit SHA to reduce supply chain risk.

| Action | Tag | SHA |
|--------|-----|-----|
| pypa/gh-action-pypi-publish | release/v1 | cef22109 |