### PR TITLE
fix: support mcp 2.0.0 (FastMCP renamed to MCPServer)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -251,7 +251,12 @@ strands-agents-sops skills --sop-paths ~/my-sops --output-dir ./skills
 - **`.github/workflows/`**: CI/CD for automated testing and publishing
 
 ### Dependencies
-- **Runtime**: MCP >=1.20.0 (only required dependency)
+- **Runtime**: MCP >=1.20.0,<3.0.0 (only required dependency)
+  - `mcp.py` must work with both mcp 1.x and 2.x: mcp 2.0.0 renamed `FastMCP` to
+    `MCPServer` and moved it from `mcp.server.fastmcp` to `mcp.server.mcpserver`, so the
+    import is a `try`/`except ImportError` shim bound to the name `MCPServer`. `hatch test`
+    runs the whole suite against both majors via the `mcp` axis of the `hatch-test` matrix, so
+    keep that axis in place when touching test config.
 - **Development**: pytest, pytest-cov, ruff
 - **Build**: hatchling, hatch-vcs
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -10,7 +10,9 @@ readme = "README.md"
 requires-python = ">=3.10"
 license = {text = "Apache-2.0"}
 dependencies = [
-    "mcp>=1.20.0",
+    # Supports both mcp 1.x and 2.x (2.0.0 renamed FastMCP to MCPServer); the
+    # upper bound keeps a future major from breaking installs again.
+    "mcp>=1.20.0,<3.0.0",
 ]
 
 [project.scripts]
@@ -42,8 +44,17 @@ dependencies = [
     "pytest-cov",
 ]
 
+# Test against both supported mcp majors: 2.0.0 renamed FastMCP to MCPServer, so
+# the compatibility shim in strands_agents_sops/mcp.py needs both paths exercised.
 [[tool.hatch.envs.hatch-test.matrix]]
 python = ["3.10", "3.11", "3.12", "3.13", "3.14"]
+mcp = ["1", "2"]
+
+[tool.hatch.envs.hatch-test.overrides]
+matrix.mcp.extra-dependencies = [
+    { value = "mcp>=1.20.0,<2.0.0", if = ["1"] },
+    { value = "mcp>=2.0.0,<3.0.0", if = ["2"] },
+]
 
 [tool.hatch.build.targets.wheel]
 include = [

--- a/python/strands_agents_sops/mcp.py
+++ b/python/strands_agents_sops/mcp.py
@@ -1,10 +1,34 @@
 import logging
 import re
+from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 
-from mcp.server.fastmcp import FastMCP
-
 from .utils import expand_sop_paths, load_external_sops
+
+
+def _package_version() -> str:
+    try:
+        return version("strands-agents-sops")
+    except PackageNotFoundError:  # pragma: no cover - running from a source tree
+        return ""
+
+
+try:
+    # mcp >= 2.0.0 renamed FastMCP to MCPServer and moved it out of
+    # mcp.server.fastmcp. Both spellings expose the prompt() and run() API used
+    # below, so support either resolved version. Both majors are exercised in CI
+    # via the mcp axis of the hatch-test matrix in pyproject.toml.
+    from mcp.server.mcpserver import MCPServer
+
+    # Their constructors differ: only MCPServer takes version= (and defaults it
+    # to "", so clients would otherwise see an empty serverInfo.version), while
+    # FastMCP rejects the kwarg and reports the mcp library's own version. Keep
+    # any other constructor argument to what both majors accept.
+    SERVER_KWARGS: dict[str, str] = {"version": _package_version()}
+except ImportError:  # pragma: no cover - depends on installed mcp version
+    from mcp.server.fastmcp import FastMCP as MCPServer
+
+    SERVER_KWARGS = {}
 
 logger = logging.getLogger(__name__)
 
@@ -15,7 +39,7 @@ def run_mcp_server(sop_paths: str | None = None):
     Args:
         sop_paths: Optional colon-separated string of external SOP directory paths
     """
-    mcp = FastMCP("agent-sop-prompt-server")
+    mcp = MCPServer("agent-sop-prompt-server", **SERVER_KWARGS)
     registered_sops = set()  # Track registered SOP names for first-wins behavior
 
     def register_sop(name: str, content: str, description: str):

--- a/python/tests/test_external_sop_loading.py
+++ b/python/tests/test_external_sop_loading.py
@@ -2,7 +2,7 @@ import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from strands_agents_sops.mcp import run_mcp_server
+from strands_agents_sops.mcp import SERVER_KWARGS, run_mcp_server
 from strands_agents_sops.utils import expand_sop_paths, load_external_sops
 
 
@@ -101,11 +101,11 @@ Test step content.
 class TestMCPIntegration:
     """Test MCP server integration with external SOPs"""
 
-    @patch("strands_agents_sops.mcp.FastMCP")
-    def test_mcp_server_with_external_sops(self, mock_fastmcp):
+    @patch("strands_agents_sops.mcp.MCPServer")
+    def test_mcp_server_with_external_sops(self, mock_mcp_server):
         """Test MCP server initialization with external SOPs"""
         mock_mcp_instance = MagicMock()
-        mock_fastmcp.return_value = mock_mcp_instance
+        mock_mcp_server.return_value = mock_mcp_instance
 
         with tempfile.TemporaryDirectory() as temp_dir:
             # Create test SOP
@@ -125,7 +125,9 @@ Test content.
             run_mcp_server(sop_paths=f"{temp_dir}")
 
             # Verify MCP server was created and run
-            mock_fastmcp.assert_called_once_with("agent-sop-prompt-server")
+            mock_mcp_server.assert_called_once_with(
+                "agent-sop-prompt-server", **SERVER_KWARGS
+            )
             mock_mcp_instance.run.assert_called_once()
 
             # Verify prompt registration was called (built-in + external SOPs)
@@ -133,11 +135,11 @@ Test content.
                 mock_mcp_instance.prompt.call_count >= 1
             )  # At least external SOP registered
 
-    @patch("strands_agents_sops.mcp.FastMCP")
-    def test_external_sops_override_builtin(self, mock_fastmcp):
+    @patch("strands_agents_sops.mcp.MCPServer")
+    def test_external_sops_override_builtin(self, mock_mcp_server):
         """Test that external SOPs override built-in SOPs with same name"""
         mock_mcp_instance = MagicMock()
-        mock_fastmcp.return_value = mock_mcp_instance
+        mock_mcp_server.return_value = mock_mcp_instance
 
         with tempfile.TemporaryDirectory() as temp_dir:
             # Create external SOP with same name as built-in
@@ -157,7 +159,9 @@ Custom implementation.
             run_mcp_server(sop_paths=f"{temp_dir}")
 
             # Verify MCP server was created and run
-            mock_fastmcp.assert_called_once_with("agent-sop-prompt-server")
+            mock_mcp_server.assert_called_once_with(
+                "agent-sop-prompt-server", **SERVER_KWARGS
+            )
             mock_mcp_instance.run.assert_called_once()
 
             # Check that prompt was registered (external should win over built-in)
@@ -172,11 +176,11 @@ Custom implementation.
             registered_description = prompt_calls[0][1]["description"]
             assert "custom version" in registered_description.lower()
 
-    @patch("strands_agents_sops.mcp.FastMCP")
-    def test_first_external_sop_wins_conflict(self, mock_fastmcp):
+    @patch("strands_agents_sops.mcp.MCPServer")
+    def test_first_external_sop_wins_conflict(self, mock_mcp_server):
         """Test that first external SOP wins when multiple external SOPs have same name"""
         mock_mcp_instance = MagicMock()
-        mock_fastmcp.return_value = mock_mcp_instance
+        mock_mcp_server.return_value = mock_mcp_instance
 
         with (
             tempfile.TemporaryDirectory() as temp_dir1,
@@ -213,17 +217,19 @@ This is the second version that should be ignored.
             registered_description = prompt_calls[0][1]["description"]
             assert "first version" in registered_description.lower()
 
-    @patch("strands_agents_sops.mcp.FastMCP")
-    def test_mcp_server_without_external_sops(self, mock_fastmcp):
+    @patch("strands_agents_sops.mcp.MCPServer")
+    def test_mcp_server_without_external_sops(self, mock_mcp_server):
         """Test MCP server works without external SOPs (backward compatibility)"""
         mock_mcp_instance = MagicMock()
-        mock_fastmcp.return_value = mock_mcp_instance
+        mock_mcp_server.return_value = mock_mcp_instance
 
         # Run MCP server without external paths
         run_mcp_server()
 
         # Verify MCP server was created and run
-        mock_fastmcp.assert_called_once_with("agent-sop-prompt-server")
+        mock_mcp_server.assert_called_once_with(
+            "agent-sop-prompt-server", **SERVER_KWARGS
+        )
         mock_mcp_instance.run.assert_called_once()
 
         # Verify built-in SOPs were registered

--- a/python/tests/test_mcp_server.py
+++ b/python/tests/test_mcp_server.py
@@ -1,0 +1,106 @@
+"""Tests for the MCP server against the real ``mcp`` library (no mocks).
+
+These exercise the ``mcp`` 1.x / 2.x compatibility shim: ``mcp`` 2.0.0 renamed
+``FastMCP`` to ``MCPServer`` and removed ``mcp.server.fastmcp``, so both the
+module-level import and the prompt registration/rendering API have to work
+against whichever ``mcp`` version is resolved at install time.
+"""
+
+import asyncio
+import inspect
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import strands_agents_sops.mcp as sops_mcp
+from strands_agents_sops.mcp import run_mcp_server
+
+EXTERNAL_SOP = """# External Test SOP
+
+## Overview
+External SOP for testing the MCP server.
+
+## Steps
+### 1. Test Step
+Test content.
+"""
+
+
+def _build_server(sop_paths):
+    """Call run_mcp_server with .run() patched out, return the server instance."""
+    captured = {}
+
+    def fake_run(self):
+        captured["server"] = self
+
+    with patch.object(sops_mcp.MCPServer, "run", fake_run):
+        run_mcp_server(sop_paths=sop_paths)
+
+    return captured["server"]
+
+
+def test_server_class_resolves_from_installed_mcp():
+    """The server class is importable whatever mcp version is installed."""
+    assert sops_mcp.MCPServer.__module__.startswith("mcp.server.")
+    assert sops_mcp.MCPServer.__name__ in ("FastMCP", "MCPServer")
+    assert callable(sops_mcp.MCPServer.prompt)
+    assert callable(sops_mcp.MCPServer.run)
+
+
+def test_server_constructor_kwargs_match_installed_mcp():
+    """version= is passed only to the mcp majors whose constructor accepts it.
+
+    mcp 2.x's MCPServer defaults version to "" (so clients see an empty
+    serverInfo.version unless it is passed), while mcp 1.x's FastMCP raises
+    TypeError on the kwarg. This pins that gating so a future constructor
+    argument cannot silently break one major.
+    """
+    parameters = inspect.signature(sops_mcp.MCPServer.__init__).parameters
+    accepted = {name for name in sops_mcp.SERVER_KWARGS if name not in parameters}
+    assert not accepted, f"MCPServer does not accept {accepted}"
+
+    if "version" in parameters:
+        assert sops_mcp.SERVER_KWARGS["version"], "server version should not be empty"
+    else:
+        assert "version" not in sops_mcp.SERVER_KWARGS
+
+
+def test_run_mcp_server_registers_prompts():
+    """SOPs are registered as prompts on a real server instance."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        (Path(temp_dir) / "external-test.sop.md").write_text(EXTERNAL_SOP)
+
+        server = _build_server(sop_paths=temp_dir)
+        prompts = asyncio.run(server.list_prompts())
+
+        registered = {prompt.name: prompt for prompt in prompts}
+        assert "external-test" in registered
+        assert "External SOP for testing" in registered["external-test"].description
+
+
+def test_run_mcp_server_prompt_renders_sop():
+    """Invoking a registered prompt renders the SOP content and user input."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        (Path(temp_dir) / "external-test.sop.md").write_text(EXTERNAL_SOP)
+
+        server = _build_server(sop_paths=temp_dir)
+        result = asyncio.run(
+            server.get_prompt("external-test", {"user_input": "do the thing"})
+        )
+
+        rendered = result.messages[0].content.text
+        assert '<agent-sop name="external-test">' in rendered
+        assert "Test content." in rendered
+        assert "do the thing" in rendered
+
+
+def test_run_mcp_server_prompt_user_input_is_optional():
+    """user_input defaults to empty so prompts work with no arguments."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        (Path(temp_dir) / "external-test.sop.md").write_text(EXTERNAL_SOP)
+
+        server = _build_server(sop_paths=temp_dir)
+        result = asyncio.run(server.get_prompt("external-test"))
+
+        rendered = result.messages[0].content.text
+        assert "<user-input>\n\n</user-input>" in rendered


### PR DESCRIPTION
mcp 2.0.0 renamed FastMCP to MCPServer and moved it from mcp.server.fastmcp to mcp.server.mcpserver, breaking the MCP server on fresh installs where pip resolves mcp>=1.20.0 to 2.0.0.

Add a try/except ImportError shim that supports both mcp 1.x and 2.x, cap the dependency at <3.0.0, and add an mcp matrix axis to hatch-test so CI exercises both majors.

Also extract build_mcp_server() from run_mcp_server() for testability, and add mock-free tests that drive the real mcp library.

Closes #76


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
